### PR TITLE
Changes necessary to build conda packages outside DESRES

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/files"]
-	path = tests/files
-	url = gerrit:/user/gullingj/msys-inputs

--- a/SConscript
+++ b/SConscript
@@ -3,6 +3,14 @@ import os
 import sys
 import subprocess
 
+#
+# Inherit environment from outside for these environment variables
+#
+TOOLCHAIN = ["CC", "CXX", "LD", "AR", "AS", "STRIP"]
+for envvar in TOOLCHAIN:
+    if envvar in os.environ:
+        env.Replace(**{envvar: os.environ[envvar]})
+
 # Avoid doing dependency checks on garden files.
 if True:
     cpp=[]
@@ -16,12 +24,18 @@ if True:
     env.Append(CFLAGS=flg, CXXFLAGS=flg)
 
 if "SCHRODINGER_SRC" not in os.environ:
+    EXTRA_CXXFLAGS = """-Wno-error=stringop-overflow
+-Wno-error=format-overflow
+-Wno-error=format-truncation
+-Wno-error=maybe-uninitialized
+-Wno-error=noexcept-type""" if env["PLATFORM"] in ("linux", "posix") else ""
+
     env.Append(
             # SSE2 for src/within.hxx.  It's optional, but way way slower without.
-            CCFLAGS='-O2 -g -msse4.1',
+            CCFLAGS=['-O2', '-g', '-msse4.1'],
             CFLAGS='-Wall',
             # sadly, need -Wno-deprecated-declarations because of boost.
-            CXXFLAGS='-std=c++14 -Wall -Werror -Wno-deprecated-declarations',
+            CXXFLAGS="-std=c++14 -Wall -Werror -Wno-deprecated-declarations " + EXTRA_CXXFLAGS,
             CPPDEFINES=[
                 'BOOST_SYSTEM_NO_DEPRECATED',
                 ],

--- a/src/SConscript
+++ b/src/SConscript
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 Import('env')
 import os
 import sys
@@ -32,7 +34,7 @@ if env.get('MSYS_WITH_LPSOLVE'):
     env.AppendUnique(LIBS=['lpsolve55'])
 
 bsx=env.get('MSYS_BOOST_SUFFIX', '')
-boost_libs=[(x+bsx) for x in ( 
+boost_libs=[(x+bsx) for x in (
     'boost_iostreams', 'boost_filesystem', 'boost_system')]
 
 env.Append(
@@ -63,18 +65,19 @@ def split_version(verstr):
     nice_verstr = re.match('([0-9\.]*)', verstr).group(0)
     return nice_verstr.split('.')
 
-def build_version_hxx( target, source, env ):
+def build_version_hxx( target, source, env):
+    ldict = {}
     with open(source[0].path) as fp:
-        exec(fp.read())
-    major, minor, micro = split_version(version)
-    print "writing", target[0].path
+        exec(fp.read(), globals(), ldict)
+    major, minor, micro = split_version(ldict["version"])
+    print("writing", target[0].path)
     with open(target[0].path, 'w') as fp:
-        print >> fp, "#define MSYS_VERSION \"%s\"" % version
-        for x in 'major', 'minor', 'micro':
+        print("#define MSYS_VERSION \"%s\"" % ldict["version"], file=fp)
+        for x in ('major', 'minor', 'micro'):
             u=x.upper()
             v=int(locals()[x])
-            print >> fp, "#define MSYS_%s_VERSION %d" % (u,v)
-        print >> fp, "#define MSYS_ABI_VERSION 1"
+            print("#define MSYS_%s_VERSION %d" % (u,v), file=fp)
+        print("#define MSYS_ABI_VERSION 1", file=fp)
 
 env.Command('version.hxx', 'version.py', build_version_hxx )
 env.AddPythonModule('version.py', prefix='msys')
@@ -119,10 +122,23 @@ else:
     inchi = inchienv.AddObject('inchi.cxx')
 
 def get_shlib_version():
+    if env['PLATFORM'] == 'darwin':
+        # See https://www.sicpers.info/2013/03/how-to-version-a-mach-o-library/
+	# When using env.InstallVersionedLib:
+        #   On OSX, the minor/micro version number cannot be above 256. With
+        #   msys 1.7.256, we get an error like "malformed 32-bit x.y.z version number: 1.7.258"
+        #   or "malformed 64-bit a.b.c.d.e version number 1.7.258.0".
+	# When not using env.InstallVersionedLib, but still using
+	#   SHLIBVERSION, I got different errors like this
+	#   scons: *** [build/lib/libmsys.1_7_258.dylib] AppleLinkInvalidCurrentVersionException : Version component 1_7_258 (from 1_7_258) is not a number
+	# Conclusion: versioned libraries do not work for micro verions above 256 on OSX
+        return ''
+
     root = Dir('#').abspath
+    ldict = {}
     with open('%s/src/version.py' % root) as fp:
-        exec(fp.read())
-    return version.replace('.', '_')
+        exec(fp.read(), globals(), ldict)
+    return ldict["version"].replace('.', '_')
 
 dtoaenv = env.Clone()
 # new gcc on OS X emits for-loop-analysis warning.
@@ -219,11 +235,11 @@ mae/ff/restraints.cxx
 mae/ff/vdwtypes.cxx
 mae/ff/virtuals.cxx
 
-mae/destro/Attribute.cxx         
-mae/destro/DestroArray.cxx       
-mae/destro/DestroBlock.cxx       
-mae/destro/Destro.cxx            
-mae/destro/DestroNamedBlock.cxx  
+mae/destro/Attribute.cxx
+mae/destro/DestroArray.cxx
+mae/destro/DestroBlock.cxx
+mae/destro/Destro.cxx
+mae/destro/DestroNamedBlock.cxx
 mae/destro/DestroRow.cxx
 mae/destro/DestroTop.cxx
 mae/destro/Maeff.cxx

--- a/tools/SConscript
+++ b/tools/SConscript
@@ -3,7 +3,7 @@ Import('libmsys')
 import os
 
 env=msysenv.Clone()
-env.Prepend(CPPPATH=['../src'], LIBS=['msys', 'msys-core'])
+env.Prepend(CPPPATH=['../src'], LIBS=[libmsys, 'msys-core'])
 
 for mod in Glob('*.py'):
     env.AddPythonModule(mod.get_path(), prefix='msys')

--- a/tools/scripts/dms-check-groups
+++ b/tools/scripts/dms-check-groups
@@ -4,7 +4,6 @@
 # . $(dirname $0)/../share/env.sh
 # exec python $0 "$@"
 #}
-
 '''
 dms-check-groups system.dms [ options ]
 
@@ -15,6 +14,7 @@ any problems with the initial model it should be evident from from just
 those terms.
 
 '''
+
 import msys
 from msys import groups
 from msys.wrap import Wrapper
@@ -28,29 +28,29 @@ def main():
     if len(args)!=1:
         parser.error("incorrect number of arguments")
 
-    print "Reading input file", args[0]
+    print("Reading input file", args[0])
     mol=msys.Load(args[0])
 
-    print "Fixing bonds"
+    print("Fixing bonds")
     Wrapper(mol).wrap()
 
     ok = True
     for table in mol.tables:
-        print "Checking midpoints for table %s with %d atoms, %d terms" % (
-            table.name, table.natoms, table.nterms)
+        print("Checking midpoints for table %s with %d atoms, %d terms" % (
+            table.name, table.natoms, table.nterms))
         bad = groups.clone_buffer_violations(table, opts.radius)
         if bad:
-            print "Violations for atoms:", ' '.join(map(str, sorted(bad)))
-            print "%d atoms, %d %s terms affected." % (
+            print("Violations for atoms:", ' '.join(map(str, sorted(bad))))
+            print("%d atoms, %d %s terms affected." % (
                     len(bad),
                     len(table.findWithAny([mol.atom(i) for i in bad])), 
-                    table.name)
+                    table.name))
             ok = False
 
     if ok:
-        print "All tables look ok"
+        print("All tables look ok")
     else:
-        print "Some tables have suspicious terms"
+        print("Some tables have suspicious terms")
     return not ok
 
 if __name__=="__main__": exit(main())

--- a/tools/scripts/dms-fix-mass
+++ b/tools/scripts/dms-fix-mass
@@ -33,23 +33,23 @@ def fixmass(atoms):
                 inconsistent.extend(atoms)
         if len(d)==1: continue
         elems.append(anum)
-        print "Found %d distinct masses for atomic number %d" % (len(d), anum)
+        print("Found %d distinct masses for atomic number %d" % (len(d), anum))
         all=[]
         for mass, atoms in d.items():
-            print "\t%f (%d)" % (mass, len(atoms))
+            print("\t%f (%d)" % (mass, len(atoms)))
             all.extend(a.mass for a in atoms)
         M=numpy.median(numpy.array(all))
-        print "===> Replacing with median value", M
+        print("===> Replacing with median value", M)
         for atoms in d.values():
             for a in atoms:
                 a.mass = M
     if inconsistent:
-        print >> sys.stderr, "Found %d atoms whose masses are inconsistent with their atomic numbers:" % len(inconsistent)
+        print("Found %d atoms whose masses are inconsistent with their atomic numbers:" % len(inconsistent), file=sys.stderr)
         for a in inconsistent:
-            print >> sys.stderr, '%8d "%s" anum %2d mass %5.3f (expected anum %2d or mass %5.3f)' % (
+            print('%8d "%s" anum %2d mass %5.3f (expected anum %2d or mass %5.3f)' % (
                     a.id, a.name, a.atomic_number, a.mass,
                     msys.GuessAtomicNumber(a.mass),
-                    msys.MassForElement(a.atomic_number))
+                    msys.MassForElement(a.atomic_number)), file=sys.stderr)
 
     return elems
 
@@ -66,22 +66,22 @@ def main():
     if len(args)!=1:
         parser.error("incorrect number of arguments")
 
-    print "Reading input file", args[0]
+    print("Reading input file", args[0])
     mol=msys.Load(args[0])
 
     atoms=mol.select(opts.selection)
-    print "Checking %d atoms" % len(atoms)
+    print("Checking %d atoms" % len(atoms))
 
     elems = fixmass(atoms)
     if not elems:
-        print "All elements have exactly consistent masses."
+        print("All elements have exactly consistent masses.")
 
     if opts.output:
-        print "Writing DMS file", opts.output
+        print("Writing DMS file", opts.output)
         msys.SaveDMS(mol, opts.output)
     else:
         if len(elems):
-            print "Inconsistent masses were found, but no output file was written."
+            print("Inconsistent masses were found, but no output file was written.")
         sys.exit(len(elems))
 
 if __name__=="__main__": exit(main())

--- a/tools/scripts/dms-fix-water-residues
+++ b/tools/scripts/dms-fix-water-residues
@@ -41,11 +41,11 @@ if __name__=="__main__":
         parser.error("incorrect number of arguments")
 
     ifile, ofile = args
-    print "Loading", ifile
+    print("Loading", ifile)
     mol = msys.Load(ifile)
-    print "Splitting..."
+    print("Splitting...")
     mol=split(mol, opts.selection)
-    print "Saving", ofile
+    print("Saving", ofile)
     msys.SaveDMS(mol, ofile)
 
 # vim: filetype=python

--- a/tools/scripts/dms-frame
+++ b/tools/scripts/dms-frame
@@ -65,9 +65,9 @@ def main():
             help='output structure file')
 
     opts = parser.parse_args()
-    print "Reading input file", opts.ifile
+    print("Reading input file", opts.ifile)
     mol=msys.Load(opts.ifile)
-    print "Input file contains %d atoms, %d bonds" % (mol.natoms, mol.nbonds)
+    print("Input file contains %d atoms, %d bonds" % (mol.natoms, mol.nbonds))
 
     if opts.input_path is not None:
         if opts.input_type is None:
@@ -77,17 +77,17 @@ def main():
         else:
             plugin = getattr(molfile, opts.input_type)
 
-        print "Reading trajectory of type %s (%s) at %s" % (
-                plugin.name, plugin.prettyname, opts.input_path)
+        print("Reading trajectory of type %s (%s) at %s" % (
+               plugin.name, plugin.prettyname, opts.input_path))
         try:
             T=plugin.read(opts.input_path, double_precision=True)
             dbl=True
         except:
             T=plugin.read(opts.input_path, double_precision=False)
             dbl=False
-        print "Trajectory contains %d frames, %d atoms" % (T.nframes, T.natoms)
+        print("Trajectory contains %d frames, %d atoms" % (T.nframes, T.natoms))
         if T.natoms != mol.natoms:
-            raise ValueError, "Trajectory and structure file have different #atoms"
+            raise ValueError("Trajectory and structure file have different #atoms")
         if opts.time is not None:
             F = T.at_time_near(opts.time)
             ind = molfile.findframe.at_time_near(T.times, F.time)
@@ -103,8 +103,8 @@ def main():
                 F = T.frame(opts.index)
             ind = opts.index
         else:
-            raise ValueError, "Specify either --index or --frame"
-        print "Selected frame %d with time %s" % (ind, F.time)
+            raise ValueError("Specify either --index or --frame")
+        print("Selected frame %d with time %s" % (ind, F.time))
         if dbl:
             mol.positions = F.dpos
         else:
@@ -112,7 +112,7 @@ def main():
         for i in range(3):
             mol.cell[i][:] = F.box[i]
         if opts.zero_velocities:
-            print "Setting velocities to zero"
+            print("Setting velocities to zero")
             for a in mol.atoms:
                 a.vx=0
                 a.vy=0
@@ -123,23 +123,23 @@ def main():
             else:
                 vel = F.vel
             if vel is None:
-                print "No velocities in frame, not updating velocities"
+                print("No velocities in frame, not updating velocities")
             else:
-                print "Updating velocities"
+                print("Updating velocities")
                 for i, a in enumerate(mol.atoms):
                     a.vel = vel[i]
 
     else:   # opts.input_path
         if opts.time is not None or opts.index is not None:
             raise ValueError("time (-t) or index (-n) specified, but no input trajectory (-i)")
-        print "Reading coordinates from input structure file."
+        print("Reading coordinates from input structure file.")
 
     if opts.wrap or opts.glue or opts.center or opts.unrotate:
-        print "Applying periodic wrapping"
+        print("Applying periodic wrapping")
         w=Wrapper(mol, center=opts.center, glue=opts.glue, unrotate=opts.unrotate)
         w.wrap()
 
-    print "Writing", opts.ofile
+    print("Writing", opts.ofile)
     msys.Save(mol, opts.ofile)
 
 if __name__=="__main__": main()

--- a/tools/scripts/dms-replicate
+++ b/tools/scripts/dms-replicate
@@ -19,28 +19,28 @@ def main():
     y=args.y if args.y is not None else args.l
     z=args.z if args.z is not None else args.l
     if None in (x,y,z):
-        print >> sys.stderr, "ERROR: Box dimensions incompletely specified"
+        print("ERROR: Box dimensions incompletely specified", file=sys.stderr)
         exit(1)
 
     if args.seed is not None:
-        print "Random number seed:", args.seed
+        print("Random number seed:", args.seed)
         numpy.random.seed(args.seed)
 
-    print "Loading '%s'" % args.ifile
+    print("Loading '%s'" % args.ifile)
     mol = msys.Load(args.ifile)
 
-    print "Assigning mass based on atomic number"
+    print("Assigning mass based on atomic number")
     for a in mol.atoms:
         a.mass = msys.MassForElement(a.atomic_number)
 
     if args.align: 
-        print "Aligning principal axis of input structure"
+        print("Aligning principal axis of input structure")
         align_principal_axes(mol)
     else:
-        print "NOT aligning principal axis of input structure"
+        print("NOT aligning principal axis of input structure")
 
     if args.randomize:
-        print "Randomizing molecule orientation"
+        print("Randomizing molecule orientation")
 
     # convert g/cm^3 to molecular density
     fac_to_gcm3 = 10.0/6.022
@@ -49,25 +49,25 @@ def main():
 
     out = replicate(mol, x, y, z, moldensity, randomize=args.randomize)
 
-    print "Eliminating redundant forcefield terms"
+    print("Eliminating redundant forcefield terms")
     out.coalesceTables()
     out = out.clone()
 
     if args.temperature is not None:
-        print "Thermalizing velocities to %sK" % args.temperature
+        print("Thermalizing velocities to %sK" % args.temperature)
         from msys import thermalize
         thermalize.apply(out, args.temperature, args.seed)
 
     if args.unbuffered:
         if not args.ofile.endswith('.dms'):
-            print "WARNING: unbuffered saves require DMS format, but output file name ends with '%s'" % (args.ofile[-4:])
-        print "Saving unbuffered DMS file '%s'" % args.ofile
+            print("WARNING: unbuffered saves require DMS format, but output file name ends with '%s'" % (args.ofile[-4:]))
+        print("Saving unbuffered DMS file '%s'" % args.ofile)
         msys.SaveDMS(out, args.ofile, unbuffered=True)
     else:
-        print "Saving '%s'" % args.ofile
+        print("Saving '%s'" % args.ofile)
         msys.Save(out, args.ofile)
 
-    print "Done"
+    print("Done")
 
 def parse_args():
     import argparse
@@ -129,13 +129,13 @@ def replicate(mol, x, y, z, density, randomize=False):
             density = trialdensity
     n=nx*ny*nz
 
-    print "Requested molecular density: %8.5f" % target_density
-    print "Actual molecular density:    %8.5f" % (n/vol)
+    print("Requested molecular density: %8.5f" % target_density)
+    print("Actual molecular density:    %8.5f" % (n/vol))
 
     cell=numpy.diag((x/nx, y/ny, z/nz))
 
-    print "Tiling %d x %d x %d: %d total copies, %d atoms" % (
-            nx,ny,nz,n,n*mol.natoms)
+    print("Tiling %d x %d x %d: %d total copies, %d atoms" % (
+            nx,ny,nz,n,n*mol.natoms))
     xshift = -0.5 * (nx-1)*cell[0]
     yshift = -0.5 * (ny-1)*cell[1]
     zshift = -0.5 * (nz-1)*cell[2]


### PR DESCRIPTION
Over the last couple evenings, I've tried to build conda packages for msys using conda-forge. The conda-forge pull request is here: https://github.com/conda-forge/staged-recipes/pull/7961. It contains the recipe. This page on azure-pipeline shows  the success on both OSX and linux: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=21175&view=logs

The changes I've made are:

1. Port scripts to python3. Previously, some of the dms-{xyz} scripts used the python2 `print` statement.

2. Port sconsutils.py to python3. In `conda-forge`, it's doesn't seem practical to build for python3 but have SCons driven by python2. It was easier to just port sconsutils.py to Python3.

3. Minor changes to sconsutils.py for OSX.
   Specifically -- I remove use of versioned `.dylib`s on OSX (SHLIBVERSION). There are some comments in the source code, but essentially this feature of the OSX linker or dyld doesn't seem to work with major/minor/micro versions above 256. So, you hit some snag with the current msys micro version number (258).

4. Add some -Wno-error strings for linux. I'm not sure why we don't hit these internally, but with the conda-forge toolchain I get some compiler warnings. Example: 
```
src/molfile/../MsysThreeRoe.hpp:622:43: warning: 'void* memcpy(void*, const void*, size_t)': specified size between 18446744073709551592 and 18446744073709551615 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
         default: return memcpy(to, from, N);
```

5. Inherit which compiler to use from external environment, so that conda can set the toolchain. It doesn't just use 'gcc' and 'clang' -- they use their own toolchains with the paths to the compiler/linker/etc passed in as environment variables that many build system take directly ("CC", etc), but scons doesn't.

cc @jgullingsrud