### PR TITLE
Add configuration from readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,4 @@
+conda:
+    file: doc/environment.yaml
+python:
+    version: 3

--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -1,0 +1,6 @@
+name: msys_docs
+channels:
+- conda-forge
+dependencies:
+- python=3.7
+- desres-msys


### PR DESCRIPTION
This configures readthedocs (https://msys.readthedocs.io/en/latest/overview.html). This setup installs the msys library through conda-forge and then builds the sphinx docs. ReadTheDocs doesn't really let you build complex packages with a C++ toolchain on their servers, which is why I have it pulling msys from conda. Howvever it does mean that the aspects of the sphinx build that depend on the installed library won't be updated on every commit to master.