### PR TITLE
Fixed Python binding for `AnnotatedSystemFlags`

### DIFF
--- a/python/annotated_system.cxx
+++ b/python/annotated_system.cxx
@@ -9,7 +9,7 @@ namespace desres { namespace msys {
 
     void export_annotated_system(module m) {
 
-        enum_<AnnotatedSystem::Flags>(m, "AnnotatedSystemFlags")
+        enum_<AnnotatedSystem::Flags>(m, "AnnotatedSystemFlags", arithmetic())
             .value("Default",           AnnotatedSystem::Default)
             .value("AllowBadCharges",   AnnotatedSystem::AllowBadCharges)
             ;


### PR DESCRIPTION
`arithmetic()` was missed out in binding the `AnnotatedSystemFlags` enum.